### PR TITLE
removed auth policy on user create, added login after user creation

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -37,6 +37,10 @@ module.exports = {
 	        return res.redirect('/user/new');
 	      }
 
+          // Log user in
+          req.session.authenticated = true;
+          req.session.User = user;
+
 	      // After successfully creating the user
 	      // redirect to the show action
 	      // From ep1-6: //res.json(user); 

--- a/config/policies.js
+++ b/config/policies.js
@@ -20,6 +20,7 @@ module.exports.policies = {
 
   user: {
   	'new': "flash",
+    'create': "flash",
   	'*': "authenticated"
   }
 


### PR DESCRIPTION
I noticed that after cloning the repo (ep12) and starting up the app, it wasn't possible to create a new user unless you already had a user created and were logged in. I removed the auth policy on the create method, so it's possible to create a user without being logged in, and I also added a few lines to log a new user in once they are created so that their user view renders without error after the redirect. Hope this is helpful!

The tutorials are really great by the way, thanks.
